### PR TITLE
Fix the X-axis label

### DIFF
--- a/IRF510-Amp-Measure.py
+++ b/IRF510-Amp-Measure.py
@@ -134,7 +134,7 @@ plt.ylabel("Amplitude" )
 plt.plot( audio_samples )
 
 plt.figure(3)
-plt.xlabel("Frequency (MHz)" )
+plt.xlabel("Frequency (Hz)" )
 plt.ylabel("Power (dBm)" )
 plt.plot( freq[1:], mag[1:] )
 


### PR DESCRIPTION
While watching the YouTube video, I noticed that there should be Hz, not MHz on the X-axis.